### PR TITLE
Update newrelic to fix node-security issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
    - 0.12
+   - 4
+   - 8

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/namshi/newrelic-winston#readme",
   "dependencies": {
     "lodash": "^3.10.0",
-    "newrelic": "^1.21.1",
+    "newrelic": "^2.4.2",
     "winston": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
According to https://github.com/newrelic/node-newrelic/blob/master/Migration%20Guide.md you don't seem to be using any functions that were changed between the 1.x and 2.x versions of node-newrelic so this should be a simple upgrade 👍  

I would recommend once it is merged that it is released as a major version bump just to be sure.